### PR TITLE
listen port console.log now uses 8080

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,4 +169,4 @@ app.get("/stats.html", async (req, res) => {
 
 
 client.login(process.env.DISCORD_TOKEN);//process.env.TEST_BOT_TOKEN);
-app.listen(process.env.PORT || 8080, () => console.log(`Listening on Port ${process.env.PORT || 90}`));
+app.listen(process.env.PORT || 8080, () => console.log(`Listening on Port ${process.env.PORT || 8080}`));


### PR DESCRIPTION
I missed this before, doesn't affect functionality.